### PR TITLE
Fix order of variables in asserts

### DIFF
--- a/test/integration.js
+++ b/test/integration.js
@@ -64,8 +64,8 @@ function getHighlightLanguage(filename: string): string {
   };
   const language = map[extension] || "";
   assert.notStrictEqual(
-    "",
     language,
+    "",
     "Cannot find the language of extension " + extension
   );
   return language;

--- a/test/languages/plaintext.js
+++ b/test/languages/plaintext.js
@@ -37,12 +37,12 @@ describe("Plaintext tests", function() {
         .replace(/\t/g, nbsp.repeat(4));
 
       const elements = testSupport.GetElementsWithClassName("plaintext");
-      assert.strictEqual(1, elements.length);
-      assert.strictEqual(1, elements[0].childNodes.length);
+      assert.strictEqual(elements.length, 1);
+      assert.strictEqual(elements[0].childNodes.length, 1);
 
       const textElement = elements[0].childNodes[0];
-      assert.strictEqual(TEXT_NODE, textElement.nodeType);
-      assert.strictEqual(expected, textElement.nodeValue);
+      assert.strictEqual(textElement.nodeType, TEXT_NODE);
+      assert.strictEqual(textElement.nodeValue, expected);
     });
   });
 });

--- a/test/linenumbering.js
+++ b/test/linenumbering.js
@@ -22,8 +22,8 @@ function checkLineNumbers(
     const attribute = node.getAttribute("href") || "";
     const match: ?(string[]) = attribute.match(lineNumberExtractorRegExp);
     const lineNumber: string = (match && match[1]) || "";
-    assert.notStrictEqual("", lineNumber);
-    assert.strictEqual(lineNumberStart + index, Number.parseInt(lineNumber));
+    assert.notStrictEqual(lineNumber, "");
+    assert.strictEqual(Number.parseInt(lineNumber), lineNumberStart + index);
   });
 }
 
@@ -36,8 +36,8 @@ describe("Line numbering plugin", function() {
       options
     );
     assert.strictEqual(
-      true,
-      testSupport.DoesElementsWithClassNameExist("line-number-margin")
+      testSupport.DoesElementsWithClassNameExist("line-number-margin"),
+      true
     );
 
     checkLineNumbers(testSupport, 1);
@@ -51,8 +51,8 @@ describe("Line numbering plugin", function() {
       options
     );
     assert.strictEqual(
-      false,
-      testSupport.DoesElementsWithClassNameExist("line-number-margin")
+      testSupport.DoesElementsWithClassNameExist("line-number-margin"),
+      false
     );
   });
 
@@ -65,8 +65,8 @@ describe("Line numbering plugin", function() {
       options
     );
     assert.strictEqual(
-      true,
-      testSupport.DoesElementsWithClassNameExist("line-number-margin")
+      testSupport.DoesElementsWithClassNameExist("line-number-margin"),
+      true
     );
 
     checkLineNumbers(testSupport, lineNumberStart);


### PR DESCRIPTION
The correct order is assert.strictEqual(actual, expected) or the like.