### PR TITLE
 Remove line and column for token processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ var isRegistered = sunlight.isRegistered(language)
 - Reorganize API:
   - Add API for getting the path and/or content of CSS files (and LESS files?).
   - code-reader.js (API should facilitate concise language parsers.)
-  - Remove line/column in tokens (no consumers of such code)!!!
   - Fix bizzare statements in language files, e.g. `const value = context.reader.current() + context.reader.read(2); // we already read the first letter`. I don’t have any idea why the first byte of the token is already read, and this makes code that produce multiple tokens inconsistent (the first byte is NOT alreay read for the second token). Sadly this means redoing most of the existing language definitions in one single commit.
 - Add more tests.
 - Revamp switchTo/switchBack mechanism. Currently it is broken when multiple languages are loaded.

--- a/src/continuation.js
+++ b/src/continuation.js
@@ -27,8 +27,6 @@ export class Continuation {
     context: ParserContext,
     continuation: Continuation,
     buffer: string,
-    line: number,
-    column: number,
     processCurrent: boolean = false
   ): Token {
     let foundCloser = false;

--- a/src/continuation.js
+++ b/src/continuation.js
@@ -83,6 +83,6 @@ export class Continuation {
     // this has significance for partial parses (e.g. for nested languages)
     if (!foundCloser) context.continuation = continuation;
 
-    return context.createToken(this.tokenName, buffer, line, column);
+    return context.createToken(this.tokenName, buffer);
   }
 }

--- a/src/default-helpers.js
+++ b/src/default-helpers.js
@@ -66,8 +66,6 @@ export class defaultAnalyzer extends Analyzer {
  */
 export function defaultNumberParser(context: ParserContext): ?Token {
   const current = context.reader.current();
-  const line = context.reader.getLine();
-  const column = context.reader.getColumn();
 
   let number: string;
   let allowDecimal = true;
@@ -101,5 +99,5 @@ export function defaultNumberParser(context: ParserContext): ?Token {
     }
     number += context.reader.read();
   }
-  return context.createToken("number", number, line, column);
+  return context.createToken("number", number);
 }

--- a/src/languages/6502asm.js
+++ b/src/languages/6502asm.js
@@ -156,9 +156,6 @@ export const customParseRules = [
     const current = context.reader.current();
     if (current !== "#") return null;
 
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     // Quick and dirty: everything between "#" (inclusive) and whitespace
     // (exclusive) is a constant too dirty.  Need to account for parens and
     // square brackets, whitespace can appear inside them. New routine: once
@@ -181,7 +178,7 @@ export const customParseRules = [
       peek = context.reader.peek();
     }
 
-    return context.createToken("constant", value, line, column);
+    return context.createToken("constant", value);
   },
 
   // labels
@@ -201,8 +198,6 @@ export const customParseRules = [
 
     return function(context: ParserContext): ?Token {
       let label, peek;
-      const line = context.reader.getLine();
-      const column = context.reader.getColumn();
 
       if (!/[A-Za-z]/.test(context.reader.current())) return null;
 
@@ -229,7 +224,7 @@ export const customParseRules = [
         label += context.reader.read();
       }
 
-      return context.createToken("label", label, line, column);
+      return context.createToken("label", label);
     };
   })()
 ];
@@ -244,8 +239,6 @@ export const caseInsensitive = true;
  */
 export function numberParser(context: ParserContext): ?Token {
   const current = context.reader.current();
-  const line = context.reader.getLine();
-  const column = context.reader.getColumn();
 
   let number;
   // is first char a digit?
@@ -269,5 +262,5 @@ export function numberParser(context: ParserContext): ?Token {
     number += context.reader.read();
   }
 
-  return context.createToken("number", number, line, column);
+  return context.createToken("number", number);
 }

--- a/src/languages/actionscript.js
+++ b/src/languages/actionscript.js
@@ -185,16 +185,8 @@ export const customParseRules = [
       while ((peek = context.reader.peek(count)) && peek.length === count)
         if (!/\s$/.test(peek)) {
           if (peek.charAt(count - 1) === "(") {
-            const line = context.reader.getLine();
-            const column = context.reader.getColumn();
             context.reader.read(token.value.length - 1);
-            return new Token(
-              token.name,
-              token.value,
-              line,
-              column,
-              token.language
-            );
+            return new Token(token.name, token.value, token.language);
           }
           break;
         }
@@ -210,9 +202,6 @@ export const customParseRules = [
     if (context.reader.current() !== "/" || peek === "/" || peek === "*")
       return null;
 
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     const isValid = (function(): boolean {
       const previousNonWsToken = context.token(context.count() - 1);
       let previousToken = null;
@@ -220,9 +209,7 @@ export const customParseRules = [
       if (context.defaultData.text !== "") {
         previousToken = context.createToken(
           "default",
-          context.defaultData.text,
-          0,
-          0
+          context.defaultData.text
         );
       } else {
         previousToken = previousNonWsToken;
@@ -272,7 +259,7 @@ export const customParseRules = [
       regexLiteral += context.reader.read();
     }
 
-    return context.createToken("regexLiteral", regexLiteral, line, column);
+    return context.createToken("regexLiteral", regexLiteral);
   }
 ];
 

--- a/src/languages/batch.js
+++ b/src/languages/batch.js
@@ -30,26 +30,19 @@ export const customParseRules = [
     )
       return null;
 
-    const colon = context.createToken(
-      "operator",
-      ":",
-      context.reader.getLine(),
-      context.reader.getColumn()
-    );
+    const colon = context.createToken("operator", ":");
 
     // Label. Read until whitespace.
     if (context.reader.isPeekEOF() || /\s/.test(context.reader.peek()))
       return null;
 
     let value = context.reader.read();
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
     while (!context.reader.isPeekEOF() && !/\s/.test(context.reader.peek()))
       value += context.reader.read();
 
     if (value === "") return null;
 
-    return [colon, context.createToken("label", value, line, column)];
+    return [colon, context.createToken("label", value)];
   },
 
   // Label after goto statements
@@ -66,14 +59,11 @@ export const customParseRules = [
     )
       return null;
 
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     let value = context.reader.current();
     while (!context.reader.isPeekEOF() && !/[\W]/.test(context.reader.peek()))
       value += context.reader.read();
 
-    return context.createToken("label", value, line, column);
+    return context.createToken("label", value);
   },
 
   // keywords have to be handled manually because strings don't have to be quoted

--- a/src/languages/common/dotnet.js
+++ b/src/languages/common/dotnet.js
@@ -19,40 +19,19 @@ export function XMLDocComment(
 
     const metaName = "xmlDocCommentMeta"; // tags and the "///" starting token
     const contentName = "xmlDocCommentContent"; // actual comments (words and stuff)
-    const tokens = [
-      context.createToken(
-        metaName,
-        commentStart,
-        context.reader.getLine(),
-        context.reader.getColumn()
-      )
-    ];
+    const tokens = [context.createToken(metaName, commentStart)];
     context.reader.read(commentStart.length - 1);
 
-    const current: {
-      name: string,
-      value: string,
-      line: number,
-      column: number
-    } = { line: 0, column: 0, value: "", name: "" };
+    const current: { name: string, value: string } = { name: "", value: "" };
 
     while (!context.reader.isPeekEOF()) {
       const peek = context.reader.peek();
       if (peek === "<" && current.name !== metaName) {
         // push the current token
         if (current.value !== "")
-          tokens.push(
-            context.createToken(
-              current.name,
-              current.value,
-              current.line,
-              current.column
-            )
-          );
+          tokens.push(context.createToken(current.name, current.value));
 
-        // amd create a token for the tag
-        current.line = context.reader.getLine();
-        current.column = context.reader.getColumn();
+        // and create a token for the tag
         current.name = metaName;
         current.value = context.reader.read();
         continue;
@@ -61,14 +40,7 @@ export function XMLDocComment(
       if (peek === ">" && current.name === metaName) {
         // close the tag
         current.value += context.reader.read();
-        tokens.push(
-          context.createToken(
-            current.name,
-            current.value,
-            current.line,
-            current.column
-          )
-        );
+        tokens.push(context.createToken(current.name, current.value));
         current.name = "";
         current.value = "";
         continue;
@@ -76,24 +48,13 @@ export function XMLDocComment(
 
       if (peek === "\n") break;
 
-      if (current.name === "") {
-        current.name = contentName;
-        current.line = context.reader.getLine();
-        current.column = context.reader.getColumn();
-      }
+      if (current.name === "") current.name = contentName;
 
       current.value += context.reader.read();
     }
 
     if (current.name === contentName)
-      tokens.push(
-        context.createToken(
-          current.name,
-          current.value,
-          current.line,
-          current.column
-        )
-      );
+      tokens.push(context.createToken(current.name, current.value));
 
     return tokens.length > 0 ? tokens : null;
   };

--- a/src/languages/csharp.js
+++ b/src/languages/csharp.js
@@ -167,9 +167,6 @@ export const customParseRules = [
 
   // get/set contextual keyword
   function(context: ParserContext): ?Token {
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     if (!/^(get|set)\b/.test(context.reader.currentAndPeek(4))) return null;
 
     if (
@@ -203,14 +200,11 @@ export const customParseRules = [
     if (!allGoodYo) return null;
 
     const value = context.reader.current() + context.reader.read(2); // we already read the first letter
-    return context.createToken("keyword", value, line, column);
+    return context.createToken("keyword", value);
   },
 
   // value contextual keyword
   function(context: ParserContext): ?Token {
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     if (!/^value\b/.test(context.reader.currentAndPeek(6))) return null;
 
     // comes after "set" but not after the closing "}" (we'll have to count them to make sure scoping is correct)
@@ -273,7 +267,7 @@ export const customParseRules = [
       return null;
 
     context.reader.read(4); // already read the "v" in "value"
-    return context.createToken("keyword", "value", line, column);
+    return context.createToken("keyword", "value");
   }
 ];
 

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -672,9 +672,6 @@ export const customParseRules = [
 
   // classes
   function(context: ParserContext): ?(Token[]) {
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     // we can't just make this a scope because we'll get false positives for things like ".png" in url(image.png) (image.png doesn't need to be in quotes)
     // so we detect them the hard way
 
@@ -685,16 +682,14 @@ export const customParseRules = [
 
     context.reader.read(className.length);
     return [
-      context.createToken("operator", ".", line, column),
-      context.createToken("class", className, line, column + 1)
+      context.createToken("operator", "."),
+      context.createToken("class", className)
     ];
   },
 
   // element selctors (div, html, body, etc.)
   function(context: ParserContext): ?Token {
     const current = context.reader.current();
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
 
     if (!/[A-Za-z_]/.test(current)) return null;
 
@@ -713,14 +708,11 @@ export const customParseRules = [
     if (tagName === null) return null;
 
     context.reader.read(tagName.length);
-    return context.createToken("element", current + tagName, line, column);
+    return context.createToken("element", current + tagName);
   },
 
   // hex color value
   function(context: ParserContext): ?Token {
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     if (context.reader.current() !== "#") return null;
 
     let count = 1;
@@ -742,7 +734,7 @@ export const customParseRules = [
     }
 
     context.reader.read(value.length - 1); // -1 because we already read the "#"
-    return context.createToken("hexColor", value, line, column);
+    return context.createToken("hexColor", value);
   }
 ];
 

--- a/src/languages/erlang.js
+++ b/src/languages/erlang.js
@@ -48,9 +48,6 @@ export const keywords = [
 export const customParseRules = [
   // atom/function/userDefinedFunction detection
   function(context: ParserContext): ?Token {
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     if (!/[A-Za-z_]/.test(context.reader.current())) return null;
 
     let peek;
@@ -78,7 +75,7 @@ export const customParseRules = [
     context.reader.read(ident.length - 1);
     count = 1;
 
-    if (!isFunction) return context.createToken("ident", ident, line, column);
+    if (!isFunction) return context.createToken("ident", ident);
 
     let parenCount = 1; // Already read a "(" before.
     // is it a function declaration? (preceded by -> operator)
@@ -93,12 +90,7 @@ export const customParseRules = [
               // function declaration
               context.userDefinedNameStore.addName(ident, name);
 
-              return context.createToken(
-                "userDefinedFunction",
-                ident,
-                line,
-                column
-              );
+              return context.createToken("userDefinedFunction", ident);
             }
 
             break;
@@ -112,7 +104,7 @@ export const customParseRules = [
     }
 
     // just a regular function call
-    return context.createToken("function", ident, line, column);
+    return context.createToken("function", ident);
   }
 ];
 

--- a/src/languages/haskell.js
+++ b/src/languages/haskell.js
@@ -51,9 +51,6 @@ export const keywords = [
 export const customParseRules = [
   // character literals, e.g. 'a'
   function(context: ParserContext): ?Token {
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     const peek = context.reader.peek();
     if (context.reader.current() !== "'" && peek !== "'") return null;
 
@@ -67,12 +64,7 @@ export const customParseRules = [
       // doesn't end with an apostrophe, so it's a template operator
       return null;
 
-    return context.createToken(
-      "char",
-      "'" + context.reader.read(expectedEnd),
-      line,
-      column
-    );
+    return context.createToken("char", "'" + context.reader.read(expectedEnd));
   },
 
   // look for user defined functions
@@ -80,9 +72,6 @@ export const customParseRules = [
     // read the ident, if a :: operator follows it, then it's a function definition (i guess, like i know anything about haskell)
     // or if follows newtype, class or data, we keep track of it as well
     if (!/[A-Za-z_]/.test(context.reader.current())) return null;
-
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
 
     let peek;
     let count = 0;
@@ -101,7 +90,7 @@ export const customParseRules = [
       context.userDefinedNameStore.addName(ident, name);
 
       context.reader.read(ident.length - 1); // already read the first character
-      return context.createToken("ident", ident, line, column);
+      return context.createToken("ident", ident);
     }
 
     // function definitions: start of line followed by ::
@@ -115,7 +104,7 @@ export const customParseRules = [
           context.userDefinedNameStore.addName(ident, name);
 
           context.reader.read(ident.length - 1); // already read the first character
-          return context.createToken("ident", ident, line, column);
+          return context.createToken("ident", ident);
         }
 
     return null;

--- a/src/languages/httpd.js
+++ b/src/languages/httpd.js
@@ -80,8 +80,6 @@ export const customParseRules = [
   // regex literals for mod_rewrite
   function(context: ParserContext): ?Token {
     const current = context.reader.current();
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
 
     if (/[\s\n]/.test(current)) return null;
 
@@ -110,7 +108,7 @@ export const customParseRules = [
       regexLiteral += context.reader.read();
     }
 
-    return context.createToken("regexLiteral", regexLiteral, line, column);
+    return context.createToken("regexLiteral", regexLiteral);
   },
 
   // directives: http://httpd.apache.org/docs/current/mod/quickreference.html

--- a/src/languages/javascript.js
+++ b/src/languages/javascript.js
@@ -138,12 +138,7 @@ export const customParseRules = [
     const previousNonWsToken = context.token(context.count() - 1);
     let previousToken = null;
     if (context.defaultData.text !== "")
-      previousToken = context.createToken(
-        "default",
-        context.defaultData.text,
-        context.defaultData.line,
-        context.defaultData.column
-      );
+      previousToken = context.createToken("default", context.defaultData.text);
 
     if (!previousToken) previousToken = previousNonWsToken;
 
@@ -167,9 +162,6 @@ export const customParseRules = [
         return null;
     }
 
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     // read the regex literal
     let regexLiteral = "/";
     let charClass = false;
@@ -192,7 +184,7 @@ export const customParseRules = [
     )
       regexLiteral += context.reader.read();
 
-    return context.createToken("regexLiteral", regexLiteral, line, column);
+    return context.createToken("regexLiteral", regexLiteral);
   }
 ];
 

--- a/src/languages/lisp.js
+++ b/src/languages/lisp.js
@@ -240,21 +240,13 @@ export const customParseRules = [
 
     if (peek.length !== count) return null;
 
-    const token = context.createToken(
-      "operator",
-      "#" + peek,
-      context.reader.getLine(),
-      context.reader.getColumn()
-    );
+    const token = context.createToken("operator", "#" + peek);
     context.reader.read(peek.length);
     return token;
   },
 
   // characters prepended by the #\ operator are read as idents
   function(context: ParserContext): ?Token {
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     if (context.defaultData.text !== "" || /\s/.test(context.reader.current()))
       // whitespace is not allowed
       return null;
@@ -275,14 +267,11 @@ export const customParseRules = [
       value += context.reader.read();
     }
 
-    return context.createToken("ident", value, line, column);
+    return context.createToken("ident", value);
   },
 
   // variables
   function(context: ParserContext): ?Token {
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     if (context.reader.current() !== "*") return null;
 
     const token = util.getPreviousNonWsToken(
@@ -304,7 +293,7 @@ export const customParseRules = [
       if (next === "*") break;
     }
 
-    return context.createToken("variable", value, line, column);
+    return context.createToken("variable", value);
   },
 
   // function after #' operator
@@ -312,9 +301,6 @@ export const customParseRules = [
     const boundary = new RegExp(functionBoundary);
 
     return function(context: ParserContext): ?Token {
-      const line = context.reader.getLine();
-      const column = context.reader.getColumn();
-
       if (
         context.defaultData.text !== "" ||
         boundary.test(context.reader.current())
@@ -334,7 +320,7 @@ export const customParseRules = [
         value += context.reader.read();
       }
 
-      return context.createToken("function", value, line, column);
+      return context.createToken("function", value);
     };
   })(),
 

--- a/src/languages/lua.js
+++ b/src/languages/lua.js
@@ -124,9 +124,6 @@ export const customParseRules = [
     // [=*[ string contents ]=*]
     if (context.reader.current() !== "[") return null;
 
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     let numberOfEqualsSigns = 0;
     let count = 0;
     let peek;
@@ -153,7 +150,7 @@ export const customParseRules = [
       value += context.reader.read();
     }
 
-    return context.createToken("verbatimString", value, line, column);
+    return context.createToken("verbatimString", value);
   }
 ];
 

--- a/src/languages/nginx.js
+++ b/src/languages/nginx.js
@@ -70,9 +70,6 @@ export const customParseRules = [
     const current = context.reader.current();
     if (/[\s\n]/.test(current)) return null;
 
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     let isRegexLiteral = false;
     const walker = context.getTokenWalker();
     while (walker.hasPrev()) {
@@ -123,7 +120,7 @@ export const customParseRules = [
       regexLiteral += context.reader.read();
     }
 
-    return context.createToken("regexLiteral", regexLiteral, line, column);
+    return context.createToken("regexLiteral", regexLiteral);
   },
 
   // directives, can't just make them keywords because then values (not directives) will possibly be highlighted

--- a/src/languages/objective-c.js
+++ b/src/languages/objective-c.js
@@ -238,9 +238,7 @@ export const customParseRules = [
                   possibleMessageArgument && exprCount > 1
                     ? "messageArgumentName"
                     : "messageDestination",
-                  ident,
-                  context.reader.getLine(),
-                  context.reader.getColumn()
+                  ident
                 );
                 context.reader.read(ident.length - 1);
                 return token2;
@@ -303,12 +301,7 @@ export const customParseRules = [
           )
             return null;
 
-          const token2 = context.createToken(
-            token.name,
-            token.value,
-            context.reader.getLine(),
-            context.reader.getColumn()
-          );
+          const token2 = context.createToken(token.name, token.value);
           context.reader.read(token2.value.length - 1);
           return token2;
         } else if (prevToken.value === ";") {

--- a/src/languages/perl.js
+++ b/src/languages/perl.js
@@ -520,9 +520,6 @@ export const customParseRules = [
   function(context: ParserContext): ?Token {
     if (!isValidForRegexLiteral(context)) return null;
 
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     const current = context.reader.current();
     const peek = context.reader.peek();
 
@@ -575,7 +572,7 @@ export const customParseRules = [
     )
       value += context.reader.read();
 
-    return context.createToken("regexLiteral", value, line, column);
+    return context.createToken("regexLiteral", value);
   },
 
   // raw strings
@@ -583,9 +580,6 @@ export const customParseRules = [
     // begin with q, qw, qx, or qq  with a non-alphanumeric delimiter (opening bracket/paren are closed by corresponding closing bracket/paren)
     if (context.reader.current() !== "q") return null;
     let value = "q";
-
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
 
     let readCount = 1;
     const peek = context.reader.peek();
@@ -598,16 +592,13 @@ export const customParseRules = [
     value +=
       context.reader.read(readCount - 1) +
       readBetweenDelimiters(context, context.reader.read(), true);
-    return context.createToken("rawString", value, line, column);
+    return context.createToken("rawString", value);
   },
 
   // heredoc declaration (stolen from ruby)
   function(context: ParserContext): ?Token {
     const opener = "<<";
     if (!context.reader.match(opener)) return null;
-
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
 
     // cannot be preceded by an ident or a number or a string
     const prevToken = util.getPreviousNonWsToken(
@@ -670,7 +661,7 @@ export const customParseRules = [
         context.items.heredocQueue
       );
 
-    return context.createToken("heredocDeclaration", value, line, column);
+    return context.createToken("heredocDeclaration", value);
   },
 
   // heredoc
@@ -708,9 +699,6 @@ export const customParseRules = [
         return null;
       }
 
-      const line = context.reader.getLine();
-      const column = context.reader.getColumn();
-
       // read until "\n{declaration}\n"
       while (!context.reader.isPeekEOF()) {
         const peekIdent = context.reader.peek(declaration.length + 2);
@@ -723,7 +711,7 @@ export const customParseRules = [
         }
         value += context.reader.read();
       }
-      tokens.push(context.createToken("heredoc", value, line, column));
+      tokens.push(context.createToken("heredoc", value));
       value = "";
     }
 
@@ -741,9 +729,6 @@ export const customParseRules = [
     if (context.reader.current() !== "=" || !context.reader.isStartOfLine())
       return null;
 
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     // read until "\n=cut" and then everything until the end of that line
     let value = "=";
 
@@ -756,7 +741,7 @@ export const customParseRules = [
     while (!context.reader.isPeekEOF() && context.reader.peek() !== "\n")
       value += context.reader.read();
 
-    return context.createToken("docComment", value, line, column);
+    return context.createToken("docComment", value);
   }
 ];
 

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -3242,9 +3242,6 @@ export const scopes = {
 export const customParseRules = [
   // heredoc/nowdoc
   function(context: ParserContext): ?Token {
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     let value = "<<<";
     if (!context.reader.match(value)) return null;
     context.reader.read(value.length - 1);
@@ -3271,12 +3268,7 @@ export const customParseRules = [
 
     value += context.reader.read(ident.length); // don't read the semicolon
 
-    return context.createToken(
-      isNowdoc ? "nowdoc" : "heredoc",
-      value,
-      line,
-      column
-    );
+    return context.createToken(isNowdoc ? "nowdoc" : "heredoc", value);
   }
 ];
 

--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -86,9 +86,6 @@ export const customParseRules = [
     ];
 
     return function(context: ParserContext): ?Token {
-      const line = context.reader.getLine();
-      const column = context.reader.getColumn();
-
       if (
         !/[A-Za-z_-]/.test(context.reader.current()) ||
         !/[\w-]/.test(context.reader.peek())
@@ -105,7 +102,7 @@ export const customParseRules = [
           ? "keyword"
           : ident.charAt(0) === "-" ? "switch" : "ident";
 
-      return context.createToken(tokenType, ident, line, column);
+      return context.createToken(tokenType, ident);
     };
   })(),
 
@@ -156,9 +153,6 @@ export const customParseRules = [
     const invalidVariableCharRegex = /[!@#%&,.\s]/;
 
     return function(context: ParserContext): ?Token {
-      const line = context.reader.getLine();
-      const column = context.reader.getColumn();
-
       // illegal characters in a variable: ! @ # % & , . whitespace
       if (
         context.reader.current() !== "$" ||
@@ -177,9 +171,7 @@ export const customParseRules = [
         util.contains(specialVariables, value.toUpperCase())
           ? "specialVariable"
           : "variable",
-        value,
-        line,
-        column
+        value
       );
     };
   })()

--- a/src/languages/ruby.js
+++ b/src/languages/ruby.js
@@ -135,12 +135,7 @@ export const customParseRules = [
     const previousNonWsToken = context.token(context.count() - 1);
     let previousToken = null;
     if (context.defaultData.text !== "")
-      previousToken = context.createToken(
-        "default",
-        context.defaultData.text,
-        context.defaultData.line,
-        context.defaultData.column
-      );
+      previousToken = context.createToken("default", context.defaultData.text);
 
     if (!previousToken) previousToken = previousNonWsToken;
 
@@ -164,9 +159,6 @@ export const customParseRules = [
         return null;
     }
 
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     // read the regex literal
     let regexLiteral = "/";
     let charClass = false;
@@ -188,7 +180,7 @@ export const customParseRules = [
     )
       regexLiteral += context.reader.read();
 
-    return context.createToken("regexLiteral", regexLiteral, line, column);
+    return context.createToken("regexLiteral", regexLiteral);
   },
 
   // symbols
@@ -241,12 +233,7 @@ export const customParseRules = [
 
     // read the symbol
     const symbol: string = /^:\w+/.exec(context.reader.substring())[0];
-    const token = context.createToken(
-      "symbol",
-      symbol,
-      context.reader.getLine(),
-      context.reader.getColumn()
-    );
+    const token = context.createToken("symbol", symbol);
     context.reader.read(symbol.length - 1); // already read the ":"
     return token;
   },
@@ -261,9 +248,6 @@ export const customParseRules = [
       !/<[\w'"`-]/.test(context.reader.peek(2))
     )
       return null;
-
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
 
     // cannot be preceded by an a number or a string
     const walker = context.getTokenWalker();
@@ -330,7 +314,7 @@ export const customParseRules = [
         context.items.heredocQueue
       );
 
-    return context.createToken("heredocDeclaration", value, line, column);
+    return context.createToken("heredocDeclaration", value);
   },
 
   // heredoc
@@ -374,9 +358,6 @@ export const customParseRules = [
         ignoreWhitespace = true;
       }
 
-      const line = context.reader.getLine();
-      const column = context.reader.getColumn();
-
       // read until "\n{declaration}\n"
       // unless the declaration is prefixed with "-", then we don't care about
       // preceding whitespace, but it must be on its own line e.g. \n[
@@ -395,7 +376,7 @@ export const customParseRules = [
         : substring.length;
       value += context.reader.read(lengthOfMatch);
 
-      tokens.push(context.createToken("heredoc", value, line, column));
+      tokens.push(context.createToken("heredoc", value));
       value = "";
     }
 
@@ -411,9 +392,6 @@ export const customParseRules = [
   function(context: ParserContext): ?Token {
     // begin with % or %q or %Q with a non-alphanumeric delimiter (opening bracket/paren are closed by corresponding closing bracket/paren)
     if (context.reader.current() !== "%") return null;
-
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
 
     let readCount = 1;
     let isRegex = false;
@@ -463,20 +441,12 @@ export const customParseRules = [
         value += context.reader.read();
       }
 
-    return context.createToken(
-      isRegex ? "regexLiteral" : "rawString",
-      value,
-      line,
-      column
-    );
+    return context.createToken(isRegex ? "regexLiteral" : "rawString", value);
   },
 
   // doc comments
   // http://www.ruby-doc.org/docs/ruby-doc-bundle/Manual/man-1.4/syntax.html#embed_doc
   function(context: ParserContext): ?Token {
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     let value = "=begin";
 
     // these begin on with a line that starts with "=begin" and end with a line that starts with "=end"
@@ -495,7 +465,7 @@ export const customParseRules = [
     while (!context.reader.isPeekEOF() && context.reader.peek() !== "\n")
       value += context.reader.read();
 
-    return context.createToken("docComment", value, line, column);
+    return context.createToken("docComment", value);
   }
 ];
 

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -146,9 +146,7 @@ export const customParseRules = [
     if (!match) return null;
     context.reader.read(match[1].length);
 
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-    return context.createToken("symbolLiteral", "'" + match[1], line, column);
+    return context.createToken("symbolLiteral", "'" + match[1]);
   },
 
   // case classes: can't distinguish between a case class and a function call so
@@ -157,9 +155,6 @@ export const customParseRules = [
     if (context.defaultData.text === "") return null;
 
     if (!/[A-Za-z]/.test(context.reader.current())) return null;
-
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
 
     const prevToken = context.token(context.count() - 1);
     if (
@@ -175,7 +170,7 @@ export const customParseRules = [
       ident += context.reader.read();
 
     context.userDefinedNameStore.addName(ident, name);
-    return context.createToken("ident", ident, line, column);
+    return context.createToken("ident", ident);
   }
 ];
 

--- a/src/languages/vb.js
+++ b/src/languages/vb.js
@@ -240,13 +240,7 @@ export const customParseRules = [
         ((prevToken.name === "operator" && prevToken.value === ".") ||
           (prevToken.name === "keyword" && prevToken.value === "Sub"))
       )
-        return new Token(
-          "ident",
-          token.value,
-          token.line,
-          token.column,
-          token.language
-        );
+        return new Token("ident", token.value, token.language);
 
       return token;
     };

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -49,8 +49,7 @@ export const customParseRules = [
   // tag names
   function(context: ParserContext): ?Token {
     const current = context.reader.current();
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
+
     if (!/[A-Za-z_]/.test(current)) return null;
 
     const prevToken = context.token(context.count() - 1);
@@ -68,14 +67,12 @@ export const customParseRules = [
     while (!context.reader.isPeekEOF() && /[.\w-]/.test(context.reader.peek()))
       tagName += context.reader.read();
 
-    return context.createToken("tagName", tagName, line, column);
+    return context.createToken("tagName", tagName);
   },
 
   // strings (attribute values)
   function(context: ParserContext): ?Token {
     const delimiter = context.reader.current();
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
 
     if (delimiter !== '"' && delimiter !== "'") return null;
 
@@ -90,14 +87,12 @@ export const customParseRules = [
       if (next === delimiter) break;
     }
 
-    return context.createToken("string", stringValue, line, column);
+    return context.createToken("string", stringValue);
   },
 
   // attributes
   function(context: ParserContext): ?Token {
     const current = context.reader.current();
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
 
     if (!/[A-Za-z_]/.test(current)) return null;
 
@@ -115,7 +110,7 @@ export const customParseRules = [
       if (/>$/.test(peek)) {
         attribute = attribute || current + peek.substring(0, peek.length - 1);
         context.reader.read(attribute.length - 1);
-        return context.createToken("attribute", attribute, line, column);
+        return context.createToken("attribute", attribute);
       }
 
       if (!attribute && /[=\s:]$/.test(peek))
@@ -130,8 +125,7 @@ export const customParseRules = [
   // entities
   function(context: ParserContext): ?Token {
     const current = context.reader.current();
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
+
     if (current !== "&") return null;
 
     // find semicolon, or whitespace, or < or >
@@ -141,9 +135,7 @@ export const customParseRules = [
       if (peek.charAt(peek.length - 1) === ";")
         return context.createToken(
           "entity",
-          current + context.reader.read(count),
-          line,
-          column
+          current + context.reader.read(count)
         );
 
       if (!/[A-Za-z0-9]$/.test(peek)) break;
@@ -156,9 +148,6 @@ export const customParseRules = [
 
   // asp.net server side comments: <%-- --%>
   function(context: ParserContext): ?Token {
-    const line = context.reader.getLine();
-    const column = context.reader.getColumn();
-
     const startAspToken = "<%--";
     const endAspToken = "--%>";
     // have to do these manually or else they get swallowed by the open tag: <%
@@ -172,7 +161,7 @@ export const customParseRules = [
 
     value += context.reader.read(endAspToken.length - 1);
 
-    return context.createToken("comment", value, line, column);
+    return context.createToken("comment", value);
   }
 ];
 

--- a/src/parse-next-token.js
+++ b/src/parse-next-token.js
@@ -61,12 +61,6 @@ function parseIdent(context: ParserContext): ?Token {
 }
 
 function parseDefault(context: ParserContext): ?Token {
-  if (context.defaultData.text === "") {
-    // new default token
-    context.defaultData.line = context.reader.getLine();
-    context.defaultData.column = context.reader.getColumn();
-  }
-
   context.defaultData.text += context.reader.current();
   return null;
 }
@@ -88,11 +82,9 @@ function parseScopes(context: ParserContext): ?Token {
       )
         continue;
 
-      const line = context.reader.getLine();
-      const column = context.reader.getColumn();
       context.reader.read(opener.length - 1);
       const continuation = new Continuation(scope, tokenName);
-      return continuation.process(context, continuation, value, line, column);
+      return continuation.process(context, continuation, value);
     }
   }
 

--- a/src/parse-next-token.js
+++ b/src/parse-next-token.js
@@ -36,20 +36,12 @@ function parseOperator(context: ParserContext): ?Token {
 function parsePunctuation(context: ParserContext): ?Token {
   const current = context.reader.current();
   if (context.language.punctuation.test(util.regexEscape(current)))
-    return context.createToken(
-      "punctuation",
-      current,
-      context.reader.getLine(),
-      context.reader.getColumn()
-    );
+    return context.createToken("punctuation", current);
 
   return null;
 }
 
 function parseIdent(context: ParserContext): ?Token {
-  const line = context.reader.getLine();
-  const column = context.reader.getColumn();
-
   if (!isIdentMatch(context)) return null;
 
   let ident = context.reader.current();
@@ -65,7 +57,7 @@ function parseIdent(context: ParserContext): ?Token {
     ident += context.reader.read();
   }
 
-  return context.createToken("ident", ident, line, column);
+  return context.createToken("ident", ident);
 }
 
 function parseDefault(context: ParserContext): ?Token {

--- a/src/parser-context.js
+++ b/src/parser-context.js
@@ -65,16 +65,7 @@ export class ParserContext {
       partialContext.continuation = null;
       // The following statement can write to this.continuation
       // TODO: clean up
-      this.tokens.push(
-        continuation.process(
-          this,
-          continuation,
-          "",
-          this.reader.getLine(),
-          this.reader.getColumn(),
-          true
-        )
-      );
+      this.tokens.push(continuation.process(this, continuation, "", true));
     }
 
     while (!this.reader.isEOF()) {

--- a/src/parser-context.js
+++ b/src/parser-context.js
@@ -84,14 +84,7 @@ export class ParserContext {
       // flush default data if needed (in pretty much all languages this is just whitespace)
       if (token !== null && token !== undefined) {
         if (this.defaultData.text !== "") {
-          this.tokens.push(
-            this.createToken(
-              "default",
-              this.defaultData.text,
-              this.defaultData.line,
-              this.defaultData.column
-            )
-          );
+          this.tokens.push(this.createToken("default", this.defaultData.text));
           this.defaultData.text = "";
         }
 
@@ -105,14 +98,7 @@ export class ParserContext {
 
     // append the last default token, if necessary
     if (this.defaultData.text !== "")
-      this.tokens.push(
-        this.createToken(
-          "default",
-          this.defaultData.text,
-          this.defaultData.line,
-          this.defaultData.column
-        )
-      );
+      this.tokens.push(this.createToken("default", this.defaultData.text));
 
     AfterTokenizeEvent.raise(this.highlighter, {
       code: unhighlightedCode,
@@ -138,13 +124,8 @@ export class ParserContext {
     return new ArrayWalker(this.tokens, this.tokens.length);
   }
 
-  createToken(
-    name: string,
-    value: string,
-    line: number,
-    column: number
-  ): Token {
-    return new Token(name, value, line, column, this.language.name);
+  createToken(name: string, value: string): Token {
+    return new Token(name, value, this.language.name);
   }
 }
 

--- a/src/token.js
+++ b/src/token.js
@@ -5,27 +5,11 @@ import { isIe } from "./constants.js";
 export class Token {
   +name: string;
   +value: string;
-  +line: number;
-  +column: number;
   +language: string;
 
-  constructor(
-    name: string,
-    value: string,
-    line: number,
-    column: number,
-    language: string
-  ) {
-    // TODO: Update after Flow issue #2646 is fixed.
-    // $FlowFixMe
+  constructor(name: string, value: string, language: string) {
     this.name = name;
-    // $FlowFixMe
     this.value = isIe ? value.replace(/\n/g, "\r") : value;
-    // $FlowFixMe
-    this.line = line;
-    // $FlowFixMe
-    this.column = column;
-    // $FlowFixMe
     this.language = language;
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -97,8 +97,6 @@ export function matchWord(
   tokenName: string,
   doNotRead: boolean = false
 ): ?Token {
-  const line = context.reader.getLine();
-  const column = context.reader.getColumn();
   wordMap = wordMap || {};
 
   let current = context.reader.current();
@@ -120,9 +118,7 @@ export function matchWord(
       context.reader.current() +
         (doNotRead
           ? context.reader.peek(subMap[index].value.length - 1)
-          : context.reader.read(subMap[index].value.length - 1)),
-      line,
-      column
+          : context.reader.read(subMap[index].value.length - 1))
     );
 
   return null;
@@ -168,13 +164,9 @@ export function getRegexpParser(
     // Fail if no match or not matching the start of a string.
     if (!match || match.index !== 0) return null;
 
-    const line = context.reader.line;
-    const column = context.reader.column;
     return context.createToken(
       tokenName,
-      context.reader.current() + context.reader.read(match[0].length - 1),
-      line,
-      column
+      context.reader.current() + context.reader.read(match[0].length - 1)
     );
   };
 }


### PR DESCRIPTION
Lines and columns for the token processing is likely broken because the code is not tested. So they are removed to simplify the code.

Remove properties line and column in
- Token
- defaultData
- Continuation.process