### PR TITLE
Refactor of CodeReader (part 4)

### DIFF
--- a/src/code-reader.js
+++ b/src/code-reader.js
@@ -15,8 +15,7 @@ export class CodeReader {
     this.length = this.text.length;
   }
 
-  // TODO: rename to "peek" after migration.
-  newPeek(count: number = 1): string {
+  peek(count: number = 1): string {
     return this.text.substr(this.index, count);
   }
 
@@ -30,30 +29,25 @@ export class CodeReader {
     return this.text.substring(this.index);
   }
 
-  // TODO: rename to "peekToEOL".
-  newPeekTillEOL(): string {
+  peekToEndOfLine(): string {
     const startIndex = this.index;
     const endIndex: number = this.text.indexOf("\n", startIndex);
     if (endIndex >= 0) return this.text.substring(startIndex, endIndex);
     return this.text.substring(startIndex);
   }
 
-  // TODO: rename to "read" after migration.
-  newRead(count: number = 1): string {
-    const ret = this.newPeek(count);
+  read(count: number = 1): string {
+    const ret = this.peek(count);
     // Advance index by the actual number of characters read, so it doesn't go
     // past the end of the text.
     this.index += ret.length;
     return ret;
   }
 
-  // TODO: rename to "isEOF" after migration.
-  newIsEOF(): boolean {
+  isEOF(): boolean {
     return this.index >= this.length;
   }
 
-  // TODO: determine whether this should be refactored. Use only at the start of
-  // a series of reads.
   isStartOfLine(): boolean {
     return this.index === 0 || this.peekWithOffset(-1) === "\n";
   }
@@ -69,7 +63,7 @@ export class CodeReader {
   }
 
   // TODO: rename to "match" after migration.
-  newMatch(str: string): boolean {
+  match(str: string): boolean {
     return this.text.substr(this.index, str.length) === str;
   }
 }

--- a/src/continuation.js
+++ b/src/continuation.js
@@ -31,28 +31,28 @@ export class Continuation {
   ): Token {
     let foundCloser = false;
 
-    while (!context.reader.newIsEOF()) {
+    while (!context.reader.isEOF()) {
       let foundEscapeSequence = false;
       for (const escapeSequence of this.escapeSequences)
-        if (context.reader.newPeek(escapeSequence.length) === escapeSequence) {
-          buffer += context.reader.newRead(escapeSequence.length);
+        if (context.reader.peek(escapeSequence.length) === escapeSequence) {
+          buffer += context.reader.read(escapeSequence.length);
           foundEscapeSequence = true;
         }
       if (foundEscapeSequence) continue;
 
-      const peekValue = context.reader.newPeek(this.closerLength);
+      const peekValue = context.reader.peek(this.closerLength);
       if (this.closer.test(peekValue)) {
         foundCloser = true;
         break;
       }
 
-      buffer += context.reader.newRead();
+      buffer += context.reader.read();
     }
 
     // TODO: Untested on multi-language settings. Probably buggy.
     if (foundCloser) {
-      if (!this.zeroWidth && !context.reader.newIsEOF())
-        buffer += context.reader.newRead(this.closerLength);
+      if (!this.zeroWidth && !context.reader.isEOF())
+        buffer += context.reader.read(this.closerLength);
     } else {
       // This scope is not closed. We are now at EOF, and will continue with the
       // scope in the next partial parse.

--- a/src/default-helpers.js
+++ b/src/default-helpers.js
@@ -65,7 +65,7 @@ export class defaultAnalyzer extends Analyzer {
  * @returns {Token?}
  */
 export function defaultNumberParser(context: ParserContext): ?Token {
-  const current = context.reader.newPeek();
+  const current = context.reader.peek();
 
   let number: string;
   let allowDecimal = true;
@@ -75,11 +75,11 @@ export function defaultNumberParser(context: ParserContext): ?Token {
       return null;
 
     // decimal without leading zero
-    number = context.reader.newRead(2);
+    number = context.reader.read(2);
     allowDecimal = false;
   } else {
-    number = context.reader.newRead();
-    if (current === "0" && context.reader.newPeek() !== ".")
+    number = context.reader.read();
+    if (current === "0" && context.reader.peek() !== ".")
       // hex or octal
       allowDecimal = false;
   }
@@ -87,21 +87,17 @@ export function defaultNumberParser(context: ParserContext): ?Token {
   // easy way out: read until it's not a number or letter
   // this will work for hex (0xef), octal (012), decimal and scientific notation (1e3)
   // anything else and you're on your own
-  while (!context.reader.newIsEOF()) {
-    const peek = context.reader.newPeek();
+  while (!context.reader.isEOF()) {
+    const peek = context.reader.peek();
     if (!/[A-Za-z0-9]/.test(peek)) {
-      if (
-        peek === "." &&
-        allowDecimal &&
-        /\d$/.test(context.reader.newPeek(2))
-      ) {
-        number += context.reader.newRead();
+      if (peek === "." && allowDecimal && /\d$/.test(context.reader.peek(2))) {
+        number += context.reader.read();
         allowDecimal = false;
         continue;
       }
       break;
     }
-    number += context.reader.newRead();
+    number += context.reader.read();
   }
   return context.createToken("number", number);
 }

--- a/src/languages/actionscript.js
+++ b/src/languages/actionscript.js
@@ -164,7 +164,7 @@ export const customParseRules = [
 
     return function(context: ParserContext): ?Token {
       // short circuit
-      if (!/[A-Za-z]/.test(context.reader.newPeek())) return null;
+      if (!/[A-Za-z]/.test(context.reader.peek())) return null;
 
       // if it follows "new" or ":", then it's not a function
       const walker = context.getTokenWalker();
@@ -187,7 +187,7 @@ export const customParseRules = [
         if (peek === "" || !/^\s$/.test(peek)) return null;
       }
 
-      context.reader.newRead(token.value.length);
+      context.reader.read(token.value.length);
       return new Token(token.name, token.value, token.language);
     };
   })(),

--- a/src/languages/batch.js
+++ b/src/languages/batch.js
@@ -25,7 +25,7 @@ export const customParseRules = [
   function(context: ParserContext): ?(Token[]) {
     if (
       !context.reader.isPrecededByWhitespaceOnly() ||
-      !context.reader.newMatch(":")
+      !context.reader.match(":")
     )
       return null;
 
@@ -34,10 +34,10 @@ export const customParseRules = [
     if (peek === ":" || peek === "" || /\s/.test(peek)) return null;
 
     // Label. Read until whitespace.
-    context.reader.newRead();
-    let value = context.reader.newRead();
-    while (!context.reader.newIsEOF() && !/\s/.test(context.reader.newPeek()))
-      value += context.reader.newRead();
+    context.reader.read();
+    let value = context.reader.read();
+    while (!context.reader.isEOF() && !/\s/.test(context.reader.peek()))
+      value += context.reader.read();
 
     if (value === "") return null;
 
@@ -61,9 +61,9 @@ export const customParseRules = [
     )
       return null;
 
-    let value = context.reader.newRead();
-    while (!context.reader.newIsEOF() && !/[\W]/.test(context.reader.newPeek()))
-      value += context.reader.newRead();
+    let value = context.reader.read();
+    while (!context.reader.isEOF() && !/[\W]/.test(context.reader.peek()))
+      value += context.reader.read();
 
     return context.createToken("label", value);
   },
@@ -223,7 +223,7 @@ export const customParseRules = [
         }
       }
 
-      context.reader.newRead(token.value.length);
+      context.reader.read(token.value.length);
       return token;
     };
   })()

--- a/src/languages/common/dotnet.js
+++ b/src/languages/common/dotnet.js
@@ -15,17 +15,17 @@ export function XMLDocComment(
   commentStart: string
 ): ParserContext => ?(Token[]) {
   return function(context: ParserContext): ?(Token[]) {
-    if (!context.reader.newMatch(commentStart)) return null;
+    if (!context.reader.match(commentStart)) return null;
 
     const metaName = "xmlDocCommentMeta"; // tags and the "///" starting token
     const contentName = "xmlDocCommentContent"; // actual comments (words and stuff)
     const tokens = [context.createToken(metaName, commentStart)];
-    context.reader.newRead(commentStart.length);
+    context.reader.read(commentStart.length);
 
     const current: { name: string, value: string } = { name: "", value: "" };
 
-    while (!context.reader.newIsEOF()) {
-      const peek = context.reader.newPeek();
+    while (!context.reader.isEOF()) {
+      const peek = context.reader.peek();
       if (peek === "<" && current.name !== metaName) {
         // push the current token
         if (current.value !== "")
@@ -33,13 +33,13 @@ export function XMLDocComment(
 
         // and create a token for the tag
         current.name = metaName;
-        current.value = context.reader.newRead();
+        current.value = context.reader.read();
         continue;
       }
 
       if (peek === ">" && current.name === metaName) {
         // close the tag
-        current.value += context.reader.newRead();
+        current.value += context.reader.read();
         tokens.push(context.createToken(current.name, current.value));
         current.name = "";
         current.value = "";
@@ -50,7 +50,7 @@ export function XMLDocComment(
 
       if (current.name === "") current.name = contentName;
 
-      current.value += context.reader.newRead();
+      current.value += context.reader.read();
     }
 
     if (current.name === contentName)

--- a/src/languages/common/regexp.js
+++ b/src/languages/common/regexp.js
@@ -55,21 +55,20 @@ function isValidRegExp(context: ParserContext): boolean {
  */
 export function ParseRegExpLiteral(context: ParserContext): ?Token {
   // Must start with a "/".
-  if (!context.reader.newMatch("/")) return null;
+  if (!context.reader.match("/")) return null;
   // Should not start with "//" (comment) or "/*" (multi-line comment).
-  if (context.reader.newMatch("//") || context.reader.newMatch("/*"))
-    return null;
+  if (context.reader.match("//") || context.reader.match("/*")) return null;
 
   if (!isValidRegExp(context)) return null;
 
   // read the regex literal
-  let regexLiteral = context.reader.newRead();
+  let regexLiteral = context.reader.read();
   let charClass = false;
-  while (!context.reader.newIsEOF()) {
-    const next = context.reader.newRead();
+  while (!context.reader.isEOF()) {
+    const next = context.reader.read();
     regexLiteral += next;
 
-    if (next === "\\") regexLiteral += context.reader.newRead();
+    if (next === "\\") regexLiteral += context.reader.read();
     else if (next === "[") charClass = true;
     else if (next === "]") charClass = false;
     else if (next === "/" && !charClass) break;
@@ -78,11 +77,8 @@ export function ParseRegExpLiteral(context: ParserContext): ?Token {
   // Read the regex modifiers. Only "g", "i" and "m", "u" and "y" are allowed,
   // but in the future extra letters may be allowed, so we allow any
   // alphabetical character here.
-  while (
-    !context.reader.newIsEOF() &&
-    /[A-Za-z]/.test(context.reader.newPeek())
-  )
-    regexLiteral += context.reader.newRead();
+  while (!context.reader.isEOF() && /[A-Za-z]/.test(context.reader.peek()))
+    regexLiteral += context.reader.read();
 
   return context.createToken("regexLiteral", regexLiteral);
 }

--- a/src/languages/csharp.js
+++ b/src/languages/csharp.js
@@ -168,7 +168,7 @@ export const customParseRules = [
   // get/set contextual keyword
   function(context: ParserContext): ?Token {
     const initialLength = "get".length;
-    if (!/^(get|set)\b/.test(context.reader.newPeek(initialLength + 1)))
+    if (!/^(get|set)\b/.test(context.reader.peek(initialLength + 1)))
       return null;
 
     if (
@@ -195,15 +195,14 @@ export const customParseRules = [
       }
     }
 
-    const value = context.reader.newRead(initialLength);
+    const value = context.reader.read(initialLength);
     return context.createToken("keyword", value);
   },
 
   // value contextual keyword
   function(context: ParserContext): ?Token {
     const initialLength = "value".length;
-    if (!/^value\b/.test(context.reader.newPeek(initialLength + 1)))
-      return null;
+    if (!/^value\b/.test(context.reader.peek(initialLength + 1))) return null;
 
     // comes after "set" but not after the closing "}" (we'll have to count them to make sure scoping is correct)
     // can't be on the left side of an assignment
@@ -250,10 +249,7 @@ export const customParseRules = [
       // nope
       return null;
 
-    return context.createToken(
-      "keyword",
-      context.reader.newRead(initialLength)
-    );
+    return context.createToken("keyword", context.reader.read(initialLength));
   }
 ];
 

--- a/src/languages/css.js
+++ b/src/languages/css.js
@@ -555,7 +555,7 @@ export const customParseRules = [
 
         if (peek === "(") {
           // this token really is a function
-          context.reader.newRead(token.value.length);
+          context.reader.read(token.value.length);
           return token;
         }
 
@@ -665,12 +665,12 @@ export const customParseRules = [
     // we can't just make this a scope because we'll get false positives for things like ".png" in url(image.png) (image.png doesn't need to be in quotes)
     // so we detect them the hard way
 
-    if (!context.reader.newMatch(".")) return null;
+    if (!context.reader.match(".")) return null;
 
     const className = peekSelectorToken(context);
     if (className === null) return null;
 
-    context.reader.newRead(className.length + 1);
+    context.reader.read(className.length + 1);
     return [
       context.createToken("operator", "."),
       context.createToken("class", className)
@@ -679,7 +679,7 @@ export const customParseRules = [
 
   // element selctors (div, html, body, etc.)
   function(context: ParserContext): ?Token {
-    if (!/[A-Za-z_]/.test(context.reader.newPeek())) return null;
+    if (!/[A-Za-z_]/.test(context.reader.peek())) return null;
 
     const prevToken = util.getPreviousNonWsToken(
       context.getAllTokens(),
@@ -697,13 +697,13 @@ export const customParseRules = [
 
     return context.createToken(
       "element",
-      context.reader.newRead(tagName.length + 1)
+      context.reader.read(tagName.length + 1)
     );
   },
 
   // hex color value
   function(context: ParserContext): ?Token {
-    if (!context.reader.newMatch("#")) return null;
+    if (!context.reader.match("#")) return null;
 
     let length: number = 1;
     let nonHex: boolean = false;
@@ -724,7 +724,7 @@ export const customParseRules = [
     // Should not be the "#" character alone without any hex digits following.
     if (length === 1) return null;
 
-    return context.createToken("hexColor", context.reader.newRead(length));
+    return context.createToken("hexColor", context.reader.read(length));
   }
 ];
 

--- a/src/languages/erlang.js
+++ b/src/languages/erlang.js
@@ -48,7 +48,7 @@ export const keywords = [
 export const customParseRules = [
   // atom/function/userDefinedFunction detection
   function(context: ParserContext): ?Token {
-    if (!/[A-Za-z_]/.test(context.reader.newPeek())) return null;
+    if (!/[A-Za-z_]/.test(context.reader.peek())) return null;
 
     let peek: string;
     // read the ident (they can have letters, numbers, underscores and @-signs in them)
@@ -58,7 +58,7 @@ export const customParseRules = [
       if (peek === "" || !/[\w@]/.test(peek)) break;
     }
 
-    const ident = context.reader.newPeek(offset);
+    const ident = context.reader.peek(offset);
 
     // if the next non-whitespace character is "(", then it's a function
     let isFunction = false;
@@ -76,7 +76,7 @@ export const customParseRules = [
     // but it might be a keyword or something
     if (!isFunction && !/^[A-Z_]/.test(ident)) return null;
 
-    context.reader.newRead(ident.length);
+    context.reader.read(ident.length);
     offset -= ident.length;
 
     if (!isFunction) return context.createToken("ident", ident);

--- a/src/languages/haskell.js
+++ b/src/languages/haskell.js
@@ -52,7 +52,7 @@ export const keywords = [
 export const customParseRules = [
   // character literals, e.g. 'a'
   function(context: ParserContext): ?Token {
-    if (context.reader.newPeek() !== "'") return null;
+    if (context.reader.peek() !== "'") return null;
     // to differentiate from template haskell, we'll just assume that character literals
     // are exactly one character long (or two for \' and \\) and delimited by '
 
@@ -65,14 +65,14 @@ export const customParseRules = [
       // doesn't end with an apostrophe, so it's a template operator
       return null;
 
-    return context.createToken("char", context.reader.newRead(length));
+    return context.createToken("char", context.reader.read(length));
   },
 
   // look for user defined functions
   function(context: ParserContext): ?Token {
     // read the ident, if a :: operator follows it, then it's a function definition (i guess, like i know anything about haskell)
     // or if follows newtype, class or data, we keep track of it as well
-    if (!/[A-Za-z_]/.test(context.reader.newPeek())) return null;
+    if (!/[A-Za-z_]/.test(context.reader.peek())) return null;
 
     let offset = 1;
     while (/[\w']/.test(context.reader.peekWithOffset(offset))) offset++;
@@ -102,7 +102,7 @@ export const customParseRules = [
 
     if (!isIdent) return null;
 
-    const ident = context.reader.newRead(identLength);
+    const ident = context.reader.read(identLength);
     context.userDefinedNameStore.addName(ident, name);
     return context.createToken("ident", ident);
   }

--- a/src/languages/httpd.js
+++ b/src/languages/httpd.js
@@ -68,14 +68,14 @@ export const customParseRules = [
         if (peek === ">") break;
       }
 
-      context.reader.newRead(token.value.length);
+      context.reader.read(token.value.length);
       return token;
     };
   })(),
 
   // regex literals for mod_rewrite
   function(context: ParserContext): ?Token {
-    if (/[\s\n]/.test(context.reader.newPeek())) return null;
+    if (/[\s\n]/.test(context.reader.peek())) return null;
 
     // first argument after RewriteRule, delimited by \s
     // second argument after RewriteCond, delimited by \s
@@ -95,10 +95,10 @@ export const customParseRules = [
     }
 
     // read to the end of the regex literal
-    let regexLiteral = context.reader.newRead();
-    while (!context.reader.newIsEOF()) {
-      if (/[\s\n]/.test(context.reader.newPeek())) break;
-      regexLiteral += context.reader.newRead();
+    let regexLiteral = context.reader.read();
+    while (!context.reader.isEOF()) {
+      if (/[\s\n]/.test(context.reader.peek())) break;
+      regexLiteral += context.reader.read();
     }
 
     return context.createToken("regexLiteral", regexLiteral);

--- a/src/languages/lisp.js
+++ b/src/languages/lisp.js
@@ -227,7 +227,7 @@ export const customTokens = {
 export const customParseRules = [
   // #<n>r operator where n is an integer
   function(context: ParserContext): ?Token {
-    if (context.reader.newPeek() !== "#") return null;
+    if (context.reader.peek() !== "#") return null;
 
     let offset: number;
     for (offset = 1; ; offset++) {
@@ -239,12 +239,12 @@ export const customParseRules = [
       }
     }
 
-    return context.createToken("operator", context.reader.newRead(offset + 1));
+    return context.createToken("operator", context.reader.read(offset + 1));
   },
 
   // characters prepended by the #\ operator are read as idents
   function(context: ParserContext): ?Token {
-    if (context.defaultData.text !== "" || /\s/.test(context.reader.newPeek()))
+    if (context.defaultData.text !== "" || /\s/.test(context.reader.peek()))
       // whitespace is not allowed
       return null;
 
@@ -257,10 +257,10 @@ export const customParseRules = [
       return null;
 
     // the next characters up until whitespace or ( or ) are part of the ident
-    let value = context.reader.newRead();
-    while (!context.reader.newIsEOF()) {
-      if (/[\s()]/.test(context.reader.newPeek())) break;
-      value += context.reader.newRead();
+    let value = context.reader.read();
+    while (!context.reader.isEOF()) {
+      if (/[\s()]/.test(context.reader.peek())) break;
+      value += context.reader.read();
     }
 
     return context.createToken("ident", value);
@@ -268,7 +268,7 @@ export const customParseRules = [
 
   // variables
   function(context: ParserContext): ?Token {
-    if (context.reader.newPeek() !== "*") return null;
+    if (context.reader.peek() !== "*") return null;
 
     const token = util.getPreviousNonWsToken(
       context.getAllTokens(),
@@ -281,9 +281,9 @@ export const customParseRules = [
     if (/[\s*)(]/.test(context.reader.peekWithOffset(1))) return null;
 
     // read until *
-    let value = context.reader.newRead();
-    while (!context.reader.newIsEOF()) {
-      const next = context.reader.newRead();
+    let value = context.reader.read();
+    while (!context.reader.isEOF()) {
+      const next = context.reader.read();
       value += next;
 
       if (next === "*") break;
@@ -299,7 +299,7 @@ export const customParseRules = [
     return function(context: ParserContext): ?Token {
       if (
         context.defaultData.text !== "" ||
-        boundary.test(context.reader.newPeek())
+        boundary.test(context.reader.peek())
       )
         // whitespace is not allowed or we're already at the boundary
         return null;
@@ -309,10 +309,10 @@ export const customParseRules = [
         return null;
 
       // read until function boundary
-      let value = context.reader.newRead();
-      while (!context.reader.newIsEOF()) {
-        if (boundary.test(context.reader.newPeek())) break;
-        value += context.reader.newRead();
+      let value = context.reader.read();
+      while (!context.reader.isEOF()) {
+        if (boundary.test(context.reader.peek())) break;
+        value += context.reader.read();
       }
 
       return context.createToken("function", value);

--- a/src/languages/lua.js
+++ b/src/languages/lua.js
@@ -122,7 +122,7 @@ export const customParseRules = [
   // literal strings
   function(context: ParserContext): ?Token {
     // [=*[ string contents ]=*]
-    if (context.reader.newPeek() !== "[") return null;
+    if (context.reader.peek() !== "[") return null;
 
     let offset: number;
     for (offset = 1; ; offset++) {
@@ -134,16 +134,16 @@ export const customParseRules = [
     }
     const numberOfEqualsSigns = offset - 1;
 
-    let value = context.reader.newRead(offset + 1);
+    let value = context.reader.read(offset + 1);
 
     // read until "]" + numberOfEqualsSigns + "]"
     const closer = "]" + new Array(numberOfEqualsSigns + 1).join("=") + "]";
-    while (!context.reader.newIsEOF()) {
-      if (context.reader.newMatch(closer)) {
-        value += context.reader.newRead(closer.length);
+    while (!context.reader.isEOF()) {
+      if (context.reader.match(closer)) {
+        value += context.reader.read(closer.length);
         break;
       }
-      value += context.reader.newRead();
+      value += context.reader.read();
     }
 
     return context.createToken("verbatimString", value);

--- a/src/languages/mysql.js
+++ b/src/languages/mysql.js
@@ -520,7 +520,7 @@ export const customParseRules = [
         }
       }
 
-      context.reader.newRead(token.value.length);
+      context.reader.read(token.value.length);
       return token;
     };
   })()

--- a/src/languages/nginx.js
+++ b/src/languages/nginx.js
@@ -51,7 +51,7 @@ export const customParseRules = [
         if (peek === "{") break;
       }
 
-      context.reader.newRead(token.value.length);
+      context.reader.read(token.value.length);
       return token;
     };
   })(),
@@ -62,7 +62,7 @@ export const customParseRules = [
     // or after "location ^~"
     // or after "location ~"
     // or after "location ~*"
-    const current = context.reader.newPeek();
+    const current = context.reader.peek();
     if (/[\s\n]/.test(current)) return null;
 
     let isRegexLiteral = false;
@@ -108,10 +108,10 @@ export const customParseRules = [
     if (!isRegexLiteral) return null;
 
     // read to the end of the regex literal
-    let regexLiteral = context.reader.newRead();
-    while (!context.reader.newIsEOF()) {
-      if (/[\s;\n]/.test(context.reader.newPeek())) break;
-      regexLiteral += context.reader.newRead();
+    let regexLiteral = context.reader.read();
+    while (!context.reader.isEOF()) {
+      if (/[\s;\n]/.test(context.reader.peek())) break;
+      regexLiteral += context.reader.read();
     }
 
     return context.createToken("regexLiteral", regexLiteral);
@@ -627,7 +627,7 @@ export const customParseRules = [
         (prevToken.name === "punctuation" &&
           util.contains(["{", "}", ";"], prevToken.value))
       ) {
-        context.reader.newRead(token.value.length);
+        context.reader.read(token.value.length);
         return token;
       }
 

--- a/src/languages/objective-c.js
+++ b/src/languages/objective-c.js
@@ -181,7 +181,7 @@ export const customParseRules = [
   // message destination (e.g. method calls)
   function(context: ParserContext): ?Token {
     // read the ident first
-    if (!identFirstLetter.test(context.reader.newPeek())) return null;
+    if (!identFirstLetter.test(context.reader.peek())) return null;
 
     let offset: number;
     for (offset = 1; ; offset++) {
@@ -234,7 +234,7 @@ export const customParseRules = [
                   possibleMessageArgument && exprCount > 1
                     ? "messageArgumentName"
                     : "messageDestination",
-                  context.reader.newRead(identLength)
+                  context.reader.read(identLength)
                 );
 
               return null;
@@ -294,7 +294,7 @@ export const customParseRules = [
           )
             return null;
 
-          context.reader.newRead(token.value.length);
+          context.reader.read(token.value.length);
           return token;
         } else if (prevToken.value === ";") {
           return null;

--- a/src/languages/php.js
+++ b/src/languages/php.js
@@ -3243,13 +3243,13 @@ export const customParseRules = [
   // heredoc/nowdoc
   function(context: ParserContext): ?Token {
     let value = "<<<";
-    if (!context.reader.newMatch(value)) return null;
-    context.reader.newRead(value.length);
+    if (!context.reader.match(value)) return null;
+    context.reader.read(value.length);
 
     let ident = "";
     let isNowdoc = false;
-    while (!context.reader.newIsEOF() && !context.reader.newMatch("\n")) {
-      const next = context.reader.newRead();
+    while (!context.reader.isEOF() && !context.reader.match("\n")) {
+      const next = context.reader.read();
       value += next;
 
       // Ignore NOWDOC apostophres. If an apostophre is found in places other
@@ -3260,14 +3260,11 @@ export const customParseRules = [
     }
 
     // Read until "\n{ident};"
-    while (
-      !context.reader.newIsEOF() &&
-      !context.reader.newMatch("\n" + ident + ";")
-    )
-      value += context.reader.newRead();
+    while (!context.reader.isEOF() && !context.reader.match("\n" + ident + ";"))
+      value += context.reader.read();
 
     // Read "\n{ident}", but not the semicolon.
-    value += context.reader.newRead(ident.length + 1);
+    value += context.reader.read(ident.length + 1);
 
     return context.createToken(isNowdoc ? "nowdoc" : "heredoc", value);
   }

--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -87,17 +87,14 @@ export const customParseRules = [
 
     return function(context: ParserContext): ?Token {
       if (
-        !/[A-Za-z_-]/.test(context.reader.newPeek()) ||
+        !/[A-Za-z_-]/.test(context.reader.peek()) ||
         !/[\w-]/.test(context.reader.peekWithOffset(1))
       )
         return null;
 
-      let ident = context.reader.newRead();
-      while (
-        !context.reader.newIsEOF() &&
-        /[\w-]/.test(context.reader.newPeek())
-      )
-        ident += context.reader.newRead();
+      let ident = context.reader.read();
+      while (!context.reader.isEOF() && /[\w-]/.test(context.reader.peek()))
+        ident += context.reader.read();
 
       const tokenType = util.contains(specialOperators, ident)
         ? "specialOperator"
@@ -158,17 +155,17 @@ export const customParseRules = [
     return function(context: ParserContext): ?Token {
       // illegal characters in a variable: ! @ # % & , . whitespace
       if (
-        context.reader.newPeek() !== "$" ||
+        context.reader.peek() !== "$" ||
         invalidVariableCharRegex.test(context.reader.peekWithOffset(1))
       )
         return null;
 
-      let value = context.reader.newRead();
+      let value = context.reader.read();
       while (
-        !context.reader.newIsEOF() &&
-        !invalidVariableCharRegex.test(context.reader.newPeek())
+        !context.reader.isEOF() &&
+        !invalidVariableCharRegex.test(context.reader.peek())
       )
-        value += context.reader.newRead();
+        value += context.reader.read();
 
       return context.createToken(
         util.contains(specialVariables, value.toUpperCase())

--- a/src/languages/scala.js
+++ b/src/languages/scala.js
@@ -67,7 +67,7 @@ export const embeddedLanguages = {
       context.items.literalXmlNestingLevel = 0;
 
       if (
-        context.reader.newPeek() !== "<" ||
+        context.reader.peek() !== "<" ||
         !/[\w!?]/.test(context.reader.peekWithOffset(1))
       )
         return false;
@@ -137,14 +137,14 @@ export const identAfterFirstLetter = /\w/;
 export const customParseRules = [
   // symbol literals
   function(context: ParserContext): ?Token {
-    if (!context.reader.newMatch("'")) return null;
+    if (!context.reader.match("'")) return null;
 
     // TODO: don't use regular expression.
     const match: [string, string] = /^('\w+)(?!')/i.exec(
       context.reader.peekToEOF()
     );
     if (!match) return null;
-    context.reader.newRead(match[1].length);
+    context.reader.read(match[1].length);
 
     return context.createToken("symbolLiteral", match[1]);
   },
@@ -154,7 +154,7 @@ export const customParseRules = [
   function(context: ParserContext): ?Token {
     if (context.defaultData.text === "") return null;
 
-    if (!/[A-Za-z]/.test(context.reader.newPeek())) return null;
+    if (!/[A-Za-z]/.test(context.reader.peek())) return null;
 
     const prevToken = context.token(context.count() - 1);
     if (
@@ -165,9 +165,9 @@ export const customParseRules = [
       return null;
 
     // read the ident
-    let ident = context.reader.newRead();
-    while (!context.reader.newIsEOF() && /\w/.test(context.reader.newPeek()))
-      ident += context.reader.newRead();
+    let ident = context.reader.read();
+    while (!context.reader.isEOF() && /\w/.test(context.reader.peek()))
+      ident += context.reader.read();
 
     context.userDefinedNameStore.addName(ident, name);
     return context.createToken("ident", ident);

--- a/src/languages/tsql.js
+++ b/src/languages/tsql.js
@@ -463,7 +463,7 @@ export const customParseRules = [
         if (!/\s/.test(peek)) return null;
       }
 
-      context.reader.newRead(token.value.length);
+      context.reader.read(token.value.length);
       return token;
     };
   })()

--- a/src/languages/xml.js
+++ b/src/languages/xml.js
@@ -48,7 +48,7 @@ export const customTokens = {
 export const customParseRules = [
   // tag names
   function(context: ParserContext): ?Token {
-    if (!/[A-Za-z_]/.test(context.reader.newPeek())) return null;
+    if (!/[A-Za-z_]/.test(context.reader.peek())) return null;
 
     const prevToken = context.token(context.count() - 1);
     if (
@@ -59,28 +59,25 @@ export const customParseRules = [
       return null;
 
     // read the tag name
-    let tagName = context.reader.newRead();
+    let tagName = context.reader.read();
     // allow periods in tag names so that ASP.NET web.config files
     // work correctly
-    while (
-      !context.reader.newIsEOF() &&
-      /[.\w-]/.test(context.reader.newPeek())
-    )
-      tagName += context.reader.newRead();
+    while (!context.reader.isEOF() && /[.\w-]/.test(context.reader.peek()))
+      tagName += context.reader.read();
 
     return context.createToken("tagName", tagName);
   },
 
   // strings (attribute values)
   function(context: ParserContext): ?Token {
-    const delimiter = context.reader.newPeek();
+    const delimiter = context.reader.peek();
     if (delimiter !== '"' && delimiter !== "'") return null;
     if (!isInsideOpenBracket(context)) return null;
 
     // read until the delimiter
-    let stringValue = context.reader.newRead();
-    while (!context.reader.newIsEOF()) {
-      const next = context.reader.newRead();
+    let stringValue = context.reader.read();
+    while (!context.reader.isEOF()) {
+      const next = context.reader.read();
       stringValue += next;
 
       if (next === delimiter) break;
@@ -91,7 +88,7 @@ export const customParseRules = [
 
   // attributes
   function(context: ParserContext): ?Token {
-    if (!/[A-Za-z_]/.test(context.reader.newPeek())) return null;
+    if (!/[A-Za-z_]/.test(context.reader.peek())) return null;
 
     // must be between < and >
     if (!isInsideOpenBracket(context)) return null;
@@ -109,24 +106,18 @@ export const customParseRules = [
       if (!tokenLength && /[=\s:]/.test(peek)) tokenLength = offset;
     }
 
-    return context.createToken(
-      "attribute",
-      context.reader.newRead(tokenLength)
-    );
+    return context.createToken("attribute", context.reader.read(tokenLength));
   },
 
   // entities
   function(context: ParserContext): ?Token {
-    if (!context.reader.newMatch("&")) return null;
+    if (!context.reader.match("&")) return null;
 
     for (let offset = 1; ; offset++) {
       const peek = context.reader.peekWithOffset(offset);
       if (peek === "") return null;
       if (peek === ";")
-        return context.createToken(
-          "entity",
-          context.reader.newRead(offset + 1)
-        );
+        return context.createToken("entity", context.reader.read(offset + 1));
       if (!/[A-Za-z0-9]/.test(peek)) return null;
     }
   },
@@ -136,14 +127,14 @@ export const customParseRules = [
     const startAspToken = "<%--";
     const endAspToken = "--%>";
     // have to do these manually or else they get swallowed by the open tag: <%
-    if (!context.reader.newMatch(startAspToken)) return null;
+    if (!context.reader.match(startAspToken)) return null;
 
-    let value = context.reader.newRead(startAspToken.length);
+    let value = context.reader.read(startAspToken.length);
 
-    while (!context.reader.newIsEOF() && !context.reader.newMatch(endAspToken))
-      value += context.reader.newRead();
+    while (!context.reader.isEOF() && !context.reader.match(endAspToken))
+      value += context.reader.read();
 
-    value += context.reader.newRead(endAspToken.length);
+    value += context.reader.read(endAspToken.length);
 
     return context.createToken("comment", value);
   }
@@ -154,7 +145,7 @@ export const embeddedLanguages = {
     switchTo: function(context: ParserContext): boolean {
       if (context.options.enableScalaXmlInterpolation === true) return false;
 
-      if (context.reader.newMatch("</style")) return false;
+      if (context.reader.match("</style")) return false;
 
       const walker = context.getTokenWalker();
       if (!walker.hasPrev()) return false;
@@ -181,13 +172,13 @@ export const embeddedLanguages = {
     },
 
     switchBack: function(context: ParserContext): boolean {
-      return context.reader.newMatch("</style");
+      return context.reader.match("</style");
     }
   },
 
   javascript: {
     switchTo: function(context: ParserContext): boolean {
-      if (context.reader.newMatch("</script")) return false;
+      if (context.reader.match("</script")) return false;
 
       const walker = context.getTokenWalker();
       if (!walker.hasPrev()) return false;
@@ -218,13 +209,13 @@ export const embeddedLanguages = {
     },
 
     switchBack: function(context: ParserContext): boolean {
-      return context.reader.newMatch("</script");
+      return context.reader.match("</script");
     }
   },
 
   php: {
     switchTo: function(context: ParserContext): boolean {
-      return context.reader.newMatch("<?") && !context.reader.newMatch("<?xml");
+      return context.reader.match("<?") && !context.reader.match("<?xml");
     },
 
     switchBack: function(context: ParserContext): boolean {
@@ -240,7 +231,7 @@ export const embeddedLanguages = {
     },
 
     switchBack: function(context: ParserContext): boolean {
-      return context.reader.newMatch("%>");
+      return context.reader.match("%>");
     }
   },
 
@@ -249,7 +240,7 @@ export const embeddedLanguages = {
       context.items.scalaBracketNestingLevel = 0;
       return (
         context.options.enableScalaXmlInterpolation === true &&
-        context.reader.newMatch("{")
+        context.reader.match("{")
       );
     },
 

--- a/src/parse-next-token.js
+++ b/src/parse-next-token.js
@@ -30,30 +30,30 @@ function parseOperator(context: ParserContext): ?Token {
 }
 
 function parsePunctuation(context: ParserContext): ?Token {
-  const current = context.reader.newPeek();
+  const current = context.reader.peek();
   if (context.language.punctuation.test(util.regexEscape(current)))
-    return context.createToken("punctuation", context.reader.newRead());
+    return context.createToken("punctuation", context.reader.read());
 
   return null;
 }
 
 function parseIdent(context: ParserContext): ?Token {
-  if (!context.language.identFirstLetter.test(context.reader.newPeek()))
+  if (!context.language.identFirstLetter.test(context.reader.peek()))
     return null;
 
-  let ident = context.reader.newRead();
+  let ident = context.reader.read();
 
   while (
-    !context.reader.newIsEOF() &&
-    context.language.identAfterFirstLetter.test(context.reader.newPeek())
+    !context.reader.isEOF() &&
+    context.language.identAfterFirstLetter.test(context.reader.peek())
   )
-    ident += context.reader.newRead();
+    ident += context.reader.read();
 
   return context.createToken("ident", ident);
 }
 
 function parseDefault(context: ParserContext): ?Token {
-  context.defaultData.text += context.reader.newRead();
+  context.defaultData.text += context.reader.read();
   return null;
 }
 
@@ -63,7 +63,7 @@ function parseScopes(context: ParserContext): ?Token {
     for (const scope of specificScopes) {
       const opener = scope[0];
 
-      const value = context.reader.newPeek(opener.length);
+      const value = context.reader.peek(opener.length);
       if (
         opener !== value &&
         (!context.language.caseInsensitive ||
@@ -71,7 +71,7 @@ function parseScopes(context: ParserContext): ?Token {
       )
         continue;
 
-      context.reader.newRead(opener.length);
+      context.reader.read(opener.length);
       const continuation = new Continuation(scope, tokenName);
       return continuation.process(context, continuation, value);
     }
@@ -98,7 +98,7 @@ function parseCustomRules(context: ParserContext): ?Token | Token[] {
 }
 
 export function parseNextToken(context: ParserContext): ?Token | Token[] {
-  if (context.language.doNotParse.test(context.reader.newPeek()))
+  if (context.language.doNotParse.test(context.reader.peek()))
     return parseDefault(context);
 
   return (

--- a/src/parser-context.js
+++ b/src/parser-context.js
@@ -70,7 +70,7 @@ export class ParserContext {
         )
       );
 
-    while (!this.reader.newIsEOF()) {
+    while (!this.reader.isEOF()) {
       this.highlighter.switchToEmbeddedLanguageIfNecessary(this);
       const token = parseNextToken(this);
 

--- a/src/util.js
+++ b/src/util.js
@@ -99,7 +99,7 @@ export function matchWord(
 ): ?Token {
   wordMap = wordMap || {};
 
-  let current = context.reader.newPeek();
+  let current = context.reader.peek();
   if (context.language.caseInsensitive) current = current.toUpperCase();
 
   if (!wordMap[current]) return null;
@@ -108,7 +108,7 @@ export function matchWord(
 
   const index = subMap.findIndex((wordItem: *): boolean => {
     const word = wordItem.value;
-    const peek = context.reader.newPeek(word.length + 1);
+    const peek = context.reader.peek(word.length + 1);
     return word === peek || wordItem.regex.test(peek);
   });
 
@@ -116,8 +116,8 @@ export function matchWord(
     return context.createToken(
       tokenName,
       doNotRead
-        ? context.reader.newPeek(subMap[index].value.length)
-        : context.reader.newRead(subMap[index].value.length)
+        ? context.reader.peek(subMap[index].value.length)
+        : context.reader.read(subMap[index].value.length)
     );
 
   return null;
@@ -159,14 +159,11 @@ export function getRegexpParser(
   regex: RegExp
 ): ParserContext => ?Token {
   return function(context: ParserContext): ?Token {
-    const match = context.reader.newPeekTillEOL().match(regex);
+    const match = context.reader.peekToEndOfLine().match(regex);
     // Fail if no match or not matching the start of a string.
     if (!match || match.index !== 0) return null;
 
-    return context.createToken(
-      tokenName,
-      context.reader.newRead(match[0].length)
-    );
+    return context.createToken(tokenName, context.reader.read(match[0].length));
   };
 }
 


### PR DESCRIPTION
- Remove prefix "new" from the name of new methods
- Rename peekTillEOF to peekToEOF